### PR TITLE
Register "about" and "policy" route name

### DIFF
--- a/routes.js
+++ b/routes.js
@@ -7,6 +7,8 @@ routes
   .add('articles', '/articles', 'articles')
   .add('replies', '/replies', 'replies')
   .add('users', '/users', 'users')
+  .add('about')
+  .add('policy')
   // routes.add({name: 'name', pattern: '/name', page: 'name'})
   .add({
     name: 'article',


### PR DESCRIPTION
Currently when users visit editor guideline (`/editor/guideline`), the "about" and "policy" link in the footer leads to `/editor/about` and `/editor/policy`, which does not exist.

![404](https://user-images.githubusercontent.com/108608/79190075-eeaf3080-7e55-11ea-9a7b-8f4c3cef395d.gif)

This PR should (not tested though) fix the issue by registering the route name `about` and `policy` with `next-routes`.

Note: There may exist some other route may need similar process

